### PR TITLE
Fix executing commands in PowerShell

### DIFF
--- a/app/src/backend/powershell.ts
+++ b/app/src/backend/powershell.ts
@@ -1,0 +1,36 @@
+/**
+ * PowerShell utilities.
+ *
+ * @module powershell
+ */
+
+import {ChildProcess, exec} from 'child_process';
+
+import {CommandCallback} from './types';
+
+const EXE = 'powershell.exe';
+const DEFAULT_ARGS = [
+  '-ExecutionPolicy',
+  'Bypass',
+  '-NoProfile',
+  '-NonInteractive',
+  '-Command',
+];
+
+const escapeCommand = (s: string): string => s.replace(/"/g, '\\"');
+
+/**
+ * Executes a command in PowerShell.
+ *
+ * @param {string} command The command to execute.
+ * @param {CommandCallback} cb The callback called with the output after the
+ *                             command completes.
+ * @returns {ChildProcess} An event emitter of the child process.
+ * @
+ */
+const powershell = (command: string, cb: CommandCallback): ChildProcess => {
+  const cmd = `${EXE} ${DEFAULT_ARGS.join(' ')} ${escapeCommand(command)}`;
+  return exec(cmd, cb);
+};
+
+export default powershell;

--- a/app/src/backend/spec/powershell.spec.ts
+++ b/app/src/backend/spec/powershell.spec.ts
@@ -1,0 +1,39 @@
+import {ChildProcess} from 'child_process';
+import * as os from 'os';
+
+import {CommandCallback} from '../types';
+
+const powershell: PowershellFn = require('../../../app/bin/backend/powershell')
+  .default;
+
+type PowershellFn = (command: string, cb: CommandCallback) => ChildProcess;
+
+if (os.platform() === 'win32') {
+  describe('powershell', () => {
+    let originalTimeoutInterval: number;
+
+    beforeAll(() => {
+      originalTimeoutInterval = jasmine.DEFAULT_TIMEOUT_INTERVAL;
+      jasmine.DEFAULT_TIMEOUT_INTERVAL = originalTimeoutInterval * 4;
+    });
+
+    afterAll(() => {
+      jasmine.DEFAULT_TIMEOUT_INTERVAL = originalTimeoutInterval;
+    });
+
+    it('captures stdout', done => {
+      powershell('Write-Output "foo"', (_err, stdout) => {
+        expect(stdout).toBe('foo\r\n');
+        done();
+      });
+    });
+
+    it('captures stderr', done => {
+      const command = '[System.Console]::Error.WriteLine("bar")';
+      powershell(command, (_err, _stdout, stderr) => {
+        expect(stderr).toBe('bar\r\n');
+        done();
+      });
+    });
+  });
+}

--- a/app/src/backend/spec/utils.spec.ts
+++ b/app/src/backend/spec/utils.spec.ts
@@ -80,7 +80,7 @@ describe('Running', () => {
   let command: string;
 
   if (platform === 'win32') {
-    command = 'Write-Debug "Bleep Blop Bloop" -Debug';
+    command = 'Write-Output "Bleep Blop Bloop"';
   } else {
     command = "echo 'Bleep Blop Bloop'";
   }

--- a/package.json
+++ b/package.json
@@ -77,7 +77,6 @@
     "merge-stream": "^1.0.1",
     "mkdirp": "^0.5.1",
     "moment": "^2.19.3",
-    "node-powershell": "^3.3.1",
     "pem": "^1.9.7",
     "quasar-extras": "^0.0.8",
     "quasar-framework": "^0.14.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6018,13 +6018,6 @@ node-notifier@^4.1.0:
     shellwords "^0.1.0"
     which "^1.0.5"
 
-node-powershell@^3.3.1:
-  version "3.3.1"
-  resolved "https://registry.yarnpkg.com/node-powershell/-/node-powershell-3.3.1.tgz#bbf76b29f091ed83eae16ad9e7a180a13f36d113"
-  dependencies:
-    bluebird "^3.5.1"
-    chalk "^2.1.0"
-
 node-pre-gyp@^0.6.36:
   version "0.6.39"
   resolved "https://registry.yarnpkg.com/node-pre-gyp/-/node-pre-gyp-0.6.39.tgz#c00e96860b23c0e1420ac7befc5044e1d78d8649"


### PR DESCRIPTION
This fixes tests failing on Windows by replacing node-powershell with a
simple module to shell out to PowerShell. It also avoids having to deal
with EOI, which previously would be removed anywhere from the output.

Fixes #47 