### PR TITLE
Revert upload behavior to 1.2.0

### DIFF
--- a/app/src/backend/dx.ts
+++ b/app/src/backend/dx.ts
@@ -228,10 +228,6 @@ function watchRemoteFile(
     file.sizeCheckingLock = true; // acquire file size checking lock
 
     module.exports.describeDXItem(dxRemotePath, (err: any, remoteFile: any) => {
-      if (err) {
-        utils.reportBug(err);
-      }
-
       file.sizeCheckingLock = false; // release file size checking lock
       if (!remoteFile || !remoteFile.parts) {
         return;

--- a/app/src/backend/dx.ts
+++ b/app/src/backend/dx.ts
@@ -274,7 +274,7 @@ export function uploadFile(
   remoteFolder: string = '/uploads'
 ): child_process.ChildProcess {
   const basename: string = path.basename(file.path.trim());
-  const dxRemotePath: string = `${projectId}: ${remoteFolder} /${basename}`;
+  const dxRemotePath: string = `${projectId}:${remoteFolder}/${basename}`;
 
   // keep track of the largest reported progress to ensure that if callbacks
   // get out of order, the progress meter isn't jumping all around.


### PR DESCRIPTION
I.e., silently ignore errors and show no progress.

This also includes a hotfix to fix uploads being put into an empty named folder.